### PR TITLE
✨ Feat: 테스트용 도커파일 생성

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18 AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY . .
+
+RUN yarn install
+
+EXPOSE 3001
+
+CMD ["yarn", "dev"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 AS build
+FROM node:20
 
 WORKDIR /app
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+FILE_PATH=$(dirname $(realpath -s $0))
+docker build -t o2o-fe-shop -f $FILE_PATH/Dockerfile $FILE_PATH/..
+ 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -d --rm -p 3001:3001 --name o2o-fe-shop o2o-fe-shop

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,29 @@
-import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
+import { defineConfig as testConfig } from 'vitest/config'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+// Vite configuration
+const config = defineConfig({
   plugins: [react()],
+})
+
+// Vitest configuration
+const tstConfig = testConfig({
   test: {
-    globals: true,
-    environment: "jsdom",
-    setupFiles: "./src/test/setup.ts",
+    environment: 'jsdom',
   },
-});
+})
+
+// Merge configurations
+export default {
+  ...config,
+  ...tstConfig,
+  server: {
+    host: '0.0.0.0',
+    port: 3001,
+  },
+  build: {
+    outDir: './dist',
+    emptyOutDir: true,
+  },
+}


### PR DESCRIPTION
## 작업 내용
> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
- 개발서버 테스트용 도커파일 작성
- 리드미 수정
- 기본 실행 포트 변경(3001번)

## 이러한 변경이 이루어지는 이유는 무엇인가요?
도커로 프론트엔드 연동테스트 가능하면 좋겠다는 의견이 있었음. 

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.

1. 도커이미지 빌드 ```./docker/build.sh```
2. 도커이미지 실행 ```./docker/run.sh```
3. 로컬호스트 3001번으로 react 띄워지는지 확인
(고객앱은 3000번, 점주앱은 3001번으로 설정해두었습니다)

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
