### PR TITLE
✨ Feat:  husky 에러메시지 출력되도록 수정 & 커밋타입 입력 시 대소문자 자동변환

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -10,16 +10,19 @@ process_pr_merge() {
 
 # Gitmoji 매핑 처리 함수
 process_gitmoji() {
-  case "$1" in
-    Feat)    echo "✨ $COMMIT_MESSAGE" ;;
-    Design)  echo "🎨 $COMMIT_MESSAGE" ;;
-    Refactor) echo "♻️ $COMMIT_MESSAGE" ;;
-    Fix)     echo "🐛 $COMMIT_MESSAGE" ;;
-    *)       echo "❌ 커밋 메시지는 다음 형식을 따라야 합니다:" 
-             echo "   Feat: 기능"
-             echo "   Design: 디자인/문서 수정"
-             echo "   Refactor: 리팩토링"
-             echo "   Fix: 버그 수정"
+  # 입력 타입을 첫 글자만 대문자로, 나머지는 소문자로 변환
+  FORMATTED_TYPE=$(echo "$1" | awk '{print toupper(substr($0, 1, 1)) tolower(substr($0, 2))}')
+  
+  case "$FORMATTED_TYPE" in
+    Feat)    echo "✨ $FORMATTED_TYPE: $(echo "$COMMIT_MESSAGE" | cut -d':' -f2-)" ;;
+    Design)  echo "🎨 $FORMATTED_TYPE: $(echo "$COMMIT_MESSAGE" | cut -d':' -f2-)" ;;
+    Refactor) echo "♻️ $FORMATTED_TYPE: $(echo "$COMMIT_MESSAGE" | cut -d':' -f2-)" ;;
+    Fix)     echo "🐛 $FORMATTED_TYPE: $(echo "$COMMIT_MESSAGE" | cut -d':' -f2-)" ;;
+    *)       >&2 echo "❌ 커밋 메시지는 다음 형식을 따라야 합니다:"
+             >&2 echo "   Feat: 기능"
+             >&2 echo "   Design: 디자인/문서 수정"
+             >&2 echo "   Refactor: 리팩토링"
+             >&2 echo "   Fix: 버그 수정"
              exit 1 ;;
   esac
 }


### PR DESCRIPTION
## 작업 내용

- 커밋 메시지 템플릿에 맞지 않는 커밋을 추가할 경우 에러가 터미널에 출력되도록 수정함.
  - 커밋 컨벤션 `커밋타입: 커밋메시지` 
- 커밋 타입(Feat, Design 등)을 대소문자 자동변환되도록 수정
  - feat, Feat, fEAT 등 -> Feat 
![image](https://github.com/user-attachments/assets/149c9a5d-30fc-4793-b385-23346f2d984f)

## 이러한 변경이 이루어지는 이유는 무엇인가요?

기존에도 에러를 출력하는 부분이 있었지만,
husky 자체의 에러 메시지로인해 출력되지 않았음.


## 테스트 방법
1. 코드 아무거나 수정
2. git add -A
3. git commit -m "asdf"
4. 이미지와 같은 에러 메시지가 출력되는지 확인
  - ![image](https://github.com/user-attachments/assets/149c9a5d-30fc-4793-b385-23346f2d984f) 
6. git commit -m "Feat: 커밋메시지"
7. 이미지와 같은 성공 메시지가 출력되는지 확인
  - ![image](https://github.com/user-attachments/assets/625a9603-54a1-4859-9ef0-983d5ba83d70)


## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
