### PR TITLE
Feat: header 및 Main layout 구성

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,45 @@
 import { Switch } from "@components/ui/switch"
+import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@radix-ui/react-dropdown-menu"
+import Icon from "./Icon"
 
 const Header = () => {
   return (
-    <header className="sticky top-0 h-header w-full bg-boxdark">
+    <header className="sticky top-0 h-header w-full bg-netural">
       <div className="flex h-full items-center justify-end p-4">
-        <div>
+        <div className="flex items-center gap-6">
           <Switch
-            className={`data-[state=checked]:bg-primary data-[state=unchecked]:bg-secondary h-7 w-12 [&>span]:h-6 [&>span]:w-6 [&>span]:translate-x-0.5 data-[state=checked]:[&>span]:translate-x-5`}
+            className={`data-[state=checked]:bg-primary data-[state=unchecked]:bg-textLight h-7 w-12 [&>span]:h-6 [&>span]:w-6 [&>span]:translate-x-0.5 data-[state=checked]:[&>span]:translate-x-5 [&>span]:bg-background`}
           />
+          <DropdownMenu>
+            <DropdownMenuTrigger>
+              <Avatar className="block rounded-full size-12 overflow-hidden">
+                <AvatarImage src="https://github.com/shadcn.png" />
+                <AvatarFallback>CN</AvatarFallback>
+              </Avatar>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="py-2 px-3 mt-[6px] bg-netural rounded-xl shadow-lg shadow-black/20">
+              <DropdownMenuItem className="px-3 py-2 rounded-md text-2xl font-semibold cursor-pointer hover:bg-muted">
+                <div className="flex items-center gap-3">
+                  <Icon name="User" size={18} />
+                  <span>Profile</span>
+                </div>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className="h-[1px] bg-muted my-1" />
+              <DropdownMenuItem className="px-3 py-2 rounded-md text-2xl font-semibold cursor-pointer hover:bg-muted">
+                <div className="flex items-center gap-3">
+                  <Icon name="LogOut" size={18} />
+                  <span>Logout</span>
+                </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
     </header>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,10 +1,13 @@
+import Header from "@components/Header"
 import React from "react"
 
 const Main = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="flex flex-col flex-1 bg-green-500">
-      {/* <Header /> */}
-      <main className="flex-1">{children}</main>
+      <Header />
+      <main className="flex-1 bg-background p-6">
+        <div className="w-full h-full bg-white rounded-xl p-6">{children}</div>
+      </main>
     </div>
   )
 }

--- a/src/components/layout/body.tsx
+++ b/src/components/layout/body.tsx
@@ -14,7 +14,7 @@ export function Body() {
         <SidebarMenuItem className="flex justify-center">
           <SidebarMenuButton
             asChild
-            className="px-5 flex items-center text-neutral/80 active:text-neutral hover:text-neutral data-[state='open']:hover:text-neutral cursor-pointer data-[active=true]:text-netural"
+            className="px-5 flex items-center text-netural/80 active:text-netural hover:text-netural data-[state='open']:hover:text-netural cursor-pointer data-[active=true]:text-netural"
             isActive={pathname === ROUTES.DASHBOARD}
           >
             <a
@@ -32,7 +32,7 @@ export function Body() {
           <SidebarMenuItem className="flex justify-center">
             <SidebarMenuButton
               asChild
-              className="px-5 flex justify-between items-center text-neutral/80 active:text-neutral hover:text-neutral data-[state=open]:hover:text-netural data-[state='open']:hover:text-neutral data-[active=true]:text-netural data-[active=true]:text-neutral"
+              className="px-5 flex justify-between items-center text-netural/80 active:text-netural hover:text-netural data-[state=open]:hover:text-netural data-[state='open']:hover:text-netural data-[active=true]:text-netural data-[active=true]:text-netural"
               isActive={pathname.startsWith(ROUTES.ORDER)}
             >
               <CollapsibleTrigger>
@@ -55,7 +55,7 @@ export function Body() {
             <SidebarMenuItem>
               <SidebarMenuButton
                 asChild
-                className="pl-10 text-neutral/80 active:text-neutral hover:text-neutral cursor-pointer"
+                className="pl-10 text-netural/80 active:text-netural hover:text-netural cursor-pointer"
                 onClick={() => navigate(ROUTES.ACTIVE_ORDER)}
               >
                 <a>
@@ -66,7 +66,7 @@ export function Body() {
             <SidebarMenuItem>
               <SidebarMenuButton
                 asChild
-                className="pl-10 text-neutral/80 active:text-neutral hover:text-neutral cursor-pointer"
+                className="pl-10 text-netural/80 active:text-netural hover:text-netural cursor-pointer"
                 onClick={() => navigate(ROUTES.COMPLETED_ORDER)}
               >
                 <a>
@@ -87,17 +87,17 @@ export function Body() {
           <div className="flex items-center gap-3">
             <div
               data-icon
-              className="flex items-center justify-end group-hover/dashboard:bg-neutral/20 rounded-r-[5px] p-2 w-[60px] h-[48px]"
+              className="flex items-center justify-end group-hover/dashboard:bg-netural/20 rounded-r-[5px] p-2 w-[60px] h-[48px]"
             >
               <Icon
                 name={"LayoutDashboard"}
                 size={24}
-                className={pathname === ROUTES.DASHBOARD ? "text-primary" : "text-neutral/50"}
+                className={pathname === ROUTES.DASHBOARD ? "text-primary" : "text-netural/50"}
               />
             </div>
             <span
               className={`text-[16px] font-bold ${
-                pathname === ROUTES.DASHBOARD ? "text-primary" : "text-neutral/50"
+                pathname === ROUTES.DASHBOARD ? "text-primary" : "text-netural/50"
               }`}
             >
               대시보드
@@ -114,17 +114,17 @@ export function Body() {
           <div className="flex items-center gap-3">
             <div
               data-icon
-              className="flex items-center justify-end group-hover/order:bg-neutral/20 rounded-r-[5px] p-2 w-[60px] h-[48px]"
+              className="flex items-center justify-end group-hover/order:bg-netural/20 rounded-r-[5px] p-2 w-[60px] h-[48px]"
             >
               <Icon
                 name={"ClipboardPen"}
                 size={24}
-                className={pathname.startsWith(ROUTES.ORDER) ? "text-primary" : "text-neutral/50"}
+                className={pathname.startsWith(ROUTES.ORDER) ? "text-primary" : "text-netural/50"}
               />
             </div>
             <span
               className={`text-[16px] font-bold ${
-                pathname.startsWith(ROUTES.ORDER) ? "text-primary" : "text-neutral/50"
+                pathname.startsWith(ROUTES.ORDER) ? "text-primary" : "text-netural/50"
               }`}
             >
               주문

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
+import * as React from "react"
 
 import { cn } from "@/components/ui/lib/utils"
 
@@ -61,7 +61,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "z-50 min-w-[8rem] overflow-hidden rounded-xl border bg-popover p-1 text-popover-foreground shadow-lg shadow-black/20",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
@@ -167,18 +167,18 @@ DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
 
 export {
   DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuCheckboxItem,
-  DropdownMenuRadioItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
+  DropdownMenuTrigger,
 }

--- a/src/utils/routes.tsx
+++ b/src/utils/routes.tsx
@@ -29,8 +29,8 @@ export const routes: RouteObject[] = [
     element: (
       <SidebarProvider
         style={{
-          "--sidebar-width": "20rem",
-          "--sidebar-width-mobile": "20rem",
+          "--sidebar-width": "26rem",
+          "--sidebar-width-mobile": "26rem",
           "--sidebar-width-icon": "8rem",
         }}
       >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,10 +11,10 @@ const config: Config = {
         sm: "calc(var(--radius) - 4px)",
       },
       colors: {
-        background: "#1A202C",
+        background: "#F1F4FA",
         foreground: "hsl(var(--foreground))",
-        neutral: "#FFFFFF",
-        grey: "#364153",
+        netural: "#FFFFFF",
+        grey: "#EFF4FB",
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
@@ -46,7 +46,7 @@ const config: Config = {
         purple: {
           DEFAULT: "hsl(var(--purple))",
         },
-        border: "#2C3240",
+        border: "#DDDDE8",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         chart: {
@@ -70,9 +70,10 @@ const config: Config = {
         bodydark2: "#8A99AF",
         graydark: "#333A48",
         boxdark: "#242e3f",
+        textLight: "#99B2C6",
       },
       height: {
-        header: "80px",
+        header: "70px",
       },
       fontFamily: {
         sans: ["Pretendard Variable", "sans-serif"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,6 +881,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-avatar@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-avatar@npm:1.1.2"
+  dependencies:
+    "@radix-ui/react-context": "npm:1.1.1"
+    "@radix-ui/react-primitive": "npm:2.0.1"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.0"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/84a55872452e2ad07ae418d97231b4de547b176b8731541eb01f360ca1f306ae9fd2bfb6ec59ea47d90e16970db101476c3cb9c3282e4d444bf1c9d734d9c729
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-collapsible@npm:^1.1.2":
   version: 1.1.2
   resolution: "@radix-ui/react-collapsible@npm:1.1.2"
@@ -4091,6 +4113,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.17.0"
     "@heroicons/react": "npm:^2.2.0"
+    "@radix-ui/react-avatar": "npm:^1.1.2"
     "@radix-ui/react-collapsible": "npm:^1.1.2"
     "@radix-ui/react-dialog": "npm:^1.1.4"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.4"


### PR DESCRIPTION
## 작업 내용

Header 컴포넌트를 구현했습니다.

- Header 컴포넌트 내에 Switch와 Avatar (+dropdown)를 추가했습니다.
- 로고 클릭 시 대시보드 페이지로 이동하는 기능을 구현했습니다.

주요 변경사항:
- `src/components/layout/header.tsx` 파일에 Header 컴포넌트 구현
- 사이드바 컴포넌트를 활용한 헤더 레이아웃 구성
- 로고와 "개발의민족" 텍스트 추가
- React Router의 useNavigate를 사용한 페이지 이동 기능 구현

## 이러한 변경이 이루어지는 이유는 무엇인가요?

서비스의 브랜딩과 네비게이션을 위한 헤더 컴포넌트가 필요했습니다. 사용자가 서비스를 쉽게 인식하고 메인 페이지로 이동할 수 있도록 하기 위해 구현했습니다.

## 테스트 방법

1. 개발 서버를 실행합니다
2. 헤더에 로고와 "개발의민족" 텍스트가 정상적으로 표시되는지 확인합니다
3. 로고를 클릭했을 때 대시보드 페이지로 이동하는지 확인합니다
4. 반응형 디자인이 정상적으로 작동하는지 확인합니다

## 병합 전 체크리스트

- [x] 수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [x] 추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?