### PR TITLE
♻️ Refactor:  페이지 컴포넌트 파일명, 컴포넌트명 통일 (XXXPage -> Page)

### DIFF
--- a/src/pages/dashboard/page.tsx
+++ b/src/pages/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { useToast } from "@/hooks/useToast"
 
-const DashboardPage = () => {
+export default function Page() {
   const { showNewOrderNotification } = useToast()
 
   const generateRandomId = () => {
@@ -13,5 +13,3 @@ const DashboardPage = () => {
     </div>
   )
 }
-
-export default DashboardPage

--- a/src/pages/login/page.tsx
+++ b/src/pages/login/page.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 
-const LoginPage = () => {
+export default function Page() {
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50 px-4">
       <Card className="w-full max-w-md p-8">
@@ -40,5 +40,3 @@ const LoginPage = () => {
     </div>
   )
 }
-
-export default LoginPage

--- a/src/pages/orders/active/page.tsx
+++ b/src/pages/orders/active/page.tsx
@@ -2,7 +2,7 @@ import OrderDetail from "./components/OrderDetail"
 import OrderList from "./components/OrderList"
 import { OrderProvider } from "./contexts/OrderActiveProvider"
 
-export default function OrdersActivePage() {
+export default function Page() {
   return (
     <OrderProvider>
       <div className="h-[calc(100dvh-80px)] overflow-y-auto grid grid-cols-[350px_1fr] w-full">

--- a/src/pages/orders/completed/OrdersCompletedPage.tsx
+++ b/src/pages/orders/completed/OrdersCompletedPage.tsx
@@ -1,5 +1,0 @@
-const OrdersCompletedPage = () => {
-  return <>Completed Orders</>
-}
-
-export default OrdersCompletedPage

--- a/src/pages/orders/completed/page.tsx
+++ b/src/pages/orders/completed/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <>Completed Orders</>
+}

--- a/src/pages/shop/info/page.tsx
+++ b/src/pages/shop/info/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <>Store info</>
+}

--- a/src/pages/shop/menu/page.tsx
+++ b/src/pages/shop/menu/page.tsx
@@ -1,0 +1,3 @@
+export default function  Page  ()  {
+  return <div>StoreMenu</div>
+}

--- a/src/pages/shop/review/page.tsx
+++ b/src/pages/shop/review/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>StoreReview</div>
+}

--- a/src/pages/signup/Signup.tsx
+++ b/src/pages/signup/Signup.tsx
@@ -1,5 +1,0 @@
-const SignupPage = () => {
-  return <div>SignupPage</div>
-}
-
-export default SignupPage

--- a/src/pages/signup/page.tsx
+++ b/src/pages/signup/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>SignupPage</div>
+}

--- a/src/pages/store/info/StoreInfo.tsx
+++ b/src/pages/store/info/StoreInfo.tsx
@@ -1,5 +1,0 @@
-const StoreInfoPage = () => {
-  return <>Store info</>
-}
-
-export default StoreInfoPage

--- a/src/pages/store/menu/StoreMenu.tsx
+++ b/src/pages/store/menu/StoreMenu.tsx
@@ -1,5 +1,0 @@
-const StoreMenu = () => {
-  return <div>StoreMenu</div>
-}
-
-export default StoreMenu

--- a/src/pages/store/review/StoreReview.tsx
+++ b/src/pages/store/review/StoreReview.tsx
@@ -1,5 +1,0 @@
-const StoreReview = () => {
-  return <div>StoreReview</div>
-}
-
-export default StoreReview

--- a/src/utils/routes.tsx
+++ b/src/utils/routes.tsx
@@ -1,13 +1,14 @@
 import { Layout } from "@/components/layout"
 import { SidebarProvider } from "@/components/ui/sidebar"
-import DashboardPage from "@/pages/dashboard/Dashboard"
-import LoginPage from "@/pages/login/LoginPage"
-import OrdersActivePage from "@/pages/orders/active/OrdersActivePage"
-import OrdersCompletedPage from "@/pages/orders/completed/OrdersCompletedPage"
-import StoreInfoPage from "@/pages/store/info/StoreInfo"
-import StoreMenuPage from "@/pages/store/menu/StoreMenu"
-import StoreReviewPage from "@/pages/store/review/StoreReview"
 import { RouteObject } from "react-router-dom"
+
+import DashboardPage from "@/pages/dashboard/page"
+import LoginPage from "@/pages/login/page"
+import OrdersActivePage from "@/pages/orders/active/page"
+import OrdersCompletedPage from "@/pages/orders/completed/page"
+import ShopInfoPage from "@/pages/shop/info/page"
+import ShopMenuPage from "@/pages/shop/menu/page"
+import ShopReviewPage from "@/pages/shop/review/page"
 
 export const ROUTES = {
   LOGIN: "/login",
@@ -15,9 +16,9 @@ export const ROUTES = {
   ORDER: "/orders",
   COMPLETED_ORDER: "/orders/completed",
   ACTIVE_ORDER: "/orders/active",
-  STORE_INFO: "/store/info",
-  STORE_REVIEW: "/store/review",
-  STORE_MENU: "/store/menu",
+  SHOP_INFO: "/shop/info",
+  SHOP_REVIEW: "/shop/review",
+  SHOP_MENU: "/shop/menu",
 }
 
 export const routes: RouteObject[] = [
@@ -51,16 +52,16 @@ export const routes: RouteObject[] = [
         element: <OrdersActivePage />,
       },
       {
-        path: ROUTES.STORE_INFO,
-        element: <StoreInfoPage />,
+        path: ROUTES.SHOP_INFO,
+        element: <ShopInfoPage />,
       },
       {
-        path: ROUTES.STORE_REVIEW,
-        element: <StoreReviewPage />,
+        path: ROUTES.SHOP_REVIEW,
+        element: <ShopReviewPage />,
       },
       {
-        path: ROUTES.STORE_MENU,
-        element: <StoreMenuPage />,
+        path: ROUTES.SHOP_MENU,
+        element: <ShopMenuPage />,
       },
     ],
   },


### PR DESCRIPTION
## 작업 내용
- 폴더, 파일, 컴포넌트명 통일

## 이러한 변경이 이루어지는 이유는 무엇인가요?
- 폴더명 변경
  - store -> shop: zustand를 관리하는 store폴더와 중복되어 헷갈릴 수 있다는 피드백이 있었음.
  - 매장정보 관리 페이지를 store에서 shop으로 변경
  - 라우팅도 이에 맞게 변경
- 폴더명, 페이지 컴포넌트명 통일
  - XXXPage -> Page
  - 페이지 컴포넌트는 default로 export
  - nextjs의 라우팅 파일과 비슷한 방식으로 변경
- 예시
```typescript
// /src/pages/login/page.tsx
export default function Page(){
  ....
}
```  


## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1. 내용

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
